### PR TITLE
update public-ip annotation

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	addressAnnotationName = "flannel.alpha.coreos.com/public-ip-overwrite"
-	addressType           = "ExternalIP"
+	addressOverwriteAnnotationName = "flannel.alpha.coreos.com/public-ip-overwrite"
+	addressAnnotationName          = "flannel.alpha.coreos.com/public-ip"
+	addressType                    = "ExternalIP"
 )
 
 type Controller struct {
@@ -103,10 +104,12 @@ func (c *Controller) ensureAddressAnnotation(node *corev1.Node, address string) 
 	if value, exists := node.Annotations[addressAnnotationName]; !exists {
 		updated = true
 		node.Annotations[addressAnnotationName] = address
+		node.Annotations[addressOverwriteAnnotationName] = address
 	} else {
 		if value != address {
 			updated = true
 			node.Annotations[addressAnnotationName] = address
+			node.Annotations[addressOverwriteAnnotationName] = address
 		}
 	}
 	if updated {


### PR DESCRIPTION
Update `flannel.alpha.coreos.com/public-ip` annotation to make flannel use external ip right away. 
I'm running flannel 1.13 built into k3s v1.20.4 and kubelet restart is neccessary for external ip to be used when only `flannel.alpha.coreos.com/public-ip-overwrite` is updated